### PR TITLE
Open glossary via GUI

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -22,7 +22,7 @@ jobs:
       - run: |
           python3 -m pip install mypy==1.4.1
       - run: |
-          python3 -m mypy --strict linguistlab.py linguistlab_gui.py
+          python3 -m mypy --strict linguistlab.py
   pylint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -22,7 +22,7 @@ jobs:
       - run: |
           python3 -m pip install mypy==1.4.1
       - run: |
-          python3 -m mypy --strict linguistlab.py
+          python3 -m mypy --strict linguistlab.py linguistlab_gui.py
   pylint:
     runs-on: ubuntu-latest
     steps:

--- a/linguistlab.py
+++ b/linguistlab.py
@@ -5,7 +5,7 @@ from tkinter import filedialog
 from typing import Dict, List, Any, Optional
 
 
-# TODO: Handle wrongly formatted glossary/csv files
+# TODO: Handle wrongly formatted glossary/csv files and choosing "Cancel" when asking file
 def open_glossary() -> "Glossary":
     path = pathlib.Path(filedialog.askopenfilename())
 

--- a/linguistlab.py
+++ b/linguistlab.py
@@ -1,6 +1,5 @@
 import csv
 import pathlib
-import sys
 
 from tkinter import filedialog
 from typing import Dict, List, Any, Optional

--- a/linguistlab.py
+++ b/linguistlab.py
@@ -12,7 +12,7 @@ def open_glossary() -> "Glossary":
     if path.suffix != ".csv":
         raise TypeError("LinguistLab currently only supports glossaries in .csv format.")
 
-    glossary_name = path.name.split(".")[0].title()
+    glossary_name = path.stem.title()
 
     glossary_content = {}
     with open(path, newline="") as glossary_file:

--- a/linguistlab.py
+++ b/linguistlab.py
@@ -1,12 +1,22 @@
 import csv
+import pathlib
 import sys
 
+from tkinter import filedialog
 from typing import Dict, List, Any, Optional
 
 
-def read_glossary(csv_file: Any) -> Dict[str, List[str]]:
+# TODO: Handle wrongly formatted glossary/csv files
+def open_glossary() -> "Glossary":
+    path = pathlib.Path(filedialog.askopenfilename())
+
+    if path.suffix != ".csv":
+        raise TypeError("LinguistLab currently only supports glossaries in .csv format.")
+
+    glossary_name = path.name.split(".")[0].title()
+
     glossary_content = {}
-    with open(csv_file, newline="") as glossary_file:
+    with open(path, newline="") as glossary_file:
         glossary = csv.reader(glossary_file)
         for row in glossary:
             translations = []
@@ -14,7 +24,7 @@ def read_glossary(csv_file: Any) -> Dict[str, List[str]]:
                 translations.append(translation)
             glossary_content[row[0]] = translations
 
-    return glossary_content
+    return Glossary(glossary_name, glossary_content)
 
 
 class Glossary:
@@ -67,10 +77,3 @@ class Glossary:
 
     # def delete_glossary_unit(self):
     #     pass
-
-
-if __name__ == "__main__":
-    glossary_content = read_glossary(sys.argv[1])
-
-    general = Glossary("Developing", glossary_content)
-    general.search_source_term(sys.argv[2])

--- a/linguistlab_gui.py
+++ b/linguistlab_gui.py
@@ -1,0 +1,33 @@
+import customtkinter
+import linguistlab
+
+customtkinter.set_appearance_mode("System")
+customtkinter.set_default_color_theme("green")
+
+
+class LLSideBar(customtkinter.CTkFrame):
+    def __init__(self, master, linguistlab):
+        self.linguistlab = linguistlab
+        super().__init__(master)
+
+        self.btn_open_glossary = customtkinter.CTkButton(
+            master, text="Open glossary", command=linguistlab.open_glossary
+        )
+        self.btn_open_glossary.grid(row=0, column=0, sticky="n")
+
+
+class LLMainWindow(customtkinter.CTk):
+    def __init__(self, linguistlab):
+        self.linguistlab = linguistlab
+        super().__init__()
+
+        self.title("LinguistLab")
+        self.geometry("900x600")
+
+        self.sidebar = LLSideBar(self, linguistlab)
+        self.sidebar.grid(row=0, column=0, sticky="nsw")
+
+
+if __name__ == "__main__":
+    main_window = LLMainWindow(linguistlab)
+    main_window.mainloop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+customtkinter==5.2.0


### PR DESCRIPTION
I have chosen to use [customtkinter](https://github.com/TomSchimansky/CustomTkinter) for the GUI in `LinguistLab`. This will make it easier to create a program that looks nice and modern.

In this PR, the main GUI window is created with a sidebar containing a button. The button lets the user open a glossary file via the GUI and that way instantiate the `Glossary` class. 

Mypy is currently ignoring `linguistlab_gui.py` since `customtkinter` does not have any stubs. I have tried to generate stubs for it but I have not yet been successful. As soon as there are stubs for it, the gui file should be checked with mypy in Github actions.